### PR TITLE
Fixed Admin/Management to require JWT

### DIFF
--- a/src/flaskr/app/modules/api/admin/__init__.py
+++ b/src/flaskr/app/modules/api/admin/__init__.py
@@ -9,7 +9,7 @@ from .put import Put, Parser as update_admin_parser
 from .delete import Delete, Parser as delete_admin_parser
 from .reset.put import Put as ResetPut, Parser as reset_password_parser
 from .reset.post import Post as ResetPost, Parser as request_password_parser
-
+from flask_jwt_extended import (get_jwt_identity, jwt_required)
 from ...auth import authorizations
 
 admin_ns = Namespace(
@@ -23,39 +23,46 @@ admin_ns = Namespace(
 @admin_ns.response(403, "Forbidden - User is not an admin")
 class Admin(Resource):
     @admin_ns.expect(get_admin_parser)
+    @jwt_required
     def get(self):
         '''
         Returns currently registered admins. May be sorted A-Z, Z-A, oldest first, newest first.
         '''
         args = get_admin_parser.parse_args()
-        return Get(args)
+        identity = get_jwt_identity()
+        return Get(args, identity)
 
     @admin_ns.response(200, 'Admin was successfully created')
     @admin_ns.expect(add_admin_parser)
+    @jwt_required
     def post(self):
         '''
         Registers a new admin in the database
         '''
         args = add_admin_parser.parse_args()
-        return Post(args)
+        identity = get_jwt_identity()
+        return Post(args, identity)
 
     @admin_ns.response(200, 'Admin was successfully updated')
     @admin_ns.expect(update_admin_parser)
+    @jwt_required
     def put(self):
         '''
         Updates the issuing admin's information
         '''
-        return Put(request.json)
+        identity = get_jwt_identity()
+        return Put(request.json, identity)
 
     @admin_ns.response(200, 'Admin was sucessfully deleted')
     @admin_ns.expect(delete_admin_parser)
+    @jwt_required
     def delete(self):
         '''
         Deletes an admin from the database
         '''
         args = delete_admin_parser.parse_args()
-
-        return Delete(args)
+        identity = get_jwt_identity()
+        return Delete(args, identity)
 
 
 @admin_ns.route("/reset")

--- a/src/flaskr/app/modules/api/admin/delete.py
+++ b/src/flaskr/app/modules/api/admin/delete.py
@@ -1,16 +1,12 @@
 from flask import jsonify
 from flask_restplus.namespace import RequestParser
-
+from ...resources.validation import is_admin, is_not_admin_response
 #################
 # Parser        #
 #################
 
 Parser = RequestParser()
-Parser.add_argument('Authorization',
-                    help="Admin's session token",
-                    required=True)
 Parser.add_argument('id',
-                    type=int,
                     help='ID of the admin to be deleted',
                     required=True,
                     location='form')
@@ -20,7 +16,13 @@ Parser.add_argument('id',
 #################
 
 
-def Delete(args):
+def Delete(args, identity):
+
+    if not is_admin(identity):
+        response = is_not_admin_response
+    else:
+        pass
+
     admin_id = args['id']
 
     response = jsonify({

--- a/src/flaskr/app/modules/api/admin/get.py
+++ b/src/flaskr/app/modules/api/admin/get.py
@@ -1,14 +1,10 @@
 from flask import jsonify
 from flask_restplus.namespace import RequestParser
-
+from ...resources.validation import is_admin, is_not_admin_response
 #################
 # Parser        #
 #################
 Parser = RequestParser()
-
-Parser.add_argument('Authorization',
-                    help="Admin's session token",
-                    required=True)
 Parser.add_argument('sort',
                     type=int,
                     help='ID of the Sorting method to be used',
@@ -23,9 +19,14 @@ Parser.add_argument('page',
 #################
 
 
-def Get(args):
+def Get(args, identity):
+    if not is_admin(identity):
+        response = is_not_admin_response
+    else:
+        pass
     sort = 0 if not args['sort'] else args['sort']
     page = 0 if not args['page'] else args['page']
+
     response = jsonify({
         "statusCode": 200,
         "message": "Success",

--- a/src/flaskr/app/modules/api/admin/post.py
+++ b/src/flaskr/app/modules/api/admin/post.py
@@ -6,7 +6,7 @@ from flask_jwt_extended import (create_access_token, create_refresh_token,
                                 get_jwt_identity, get_raw_jwt)
 from ...resources.password_management import hash_password, verify_hash
 from ...resources.mail.reset_password import send_reset_password_email
-
+from ...resources.validation import is_admin, is_not_admin_response
 #################
 # Parser        #
 #################
@@ -31,45 +31,54 @@ Parser.add_argument(
 #################
 
 
-def Post(args):
+def Post(args, identity):
     first_name = args['first_name']
     last_name = args['last_name']
     email = args['email']
+    if not is_admin(identity):
+        response = is_not_admin_response
+    else:
+        am = AdminManagement()
 
-    am = AdminManagement()
+        try:
+            result, accessCode = am.create_admin(first_name, last_name, email)
 
-    try:
-        result, accessCode = am.create_admin(first_name, last_name, email)
-
-        if result == 1:
-            # We could make the admin and reset it's password. Email was sent through AM.
-            send_reset_password_email(accesCode, email)
-            return jsonify({
-                "statusCode":
-                200,
-                "message":
-                "Created admin and requested password reset."
+            if result == 1:
+                # We could make the admin and reset it's password. Email was sent through AM.
+                send_reset_password_email(accesCode, email)
+                response = jsonify({
+                    "statusCode":
+                    200,
+                    "message":
+                    "Created admin and requested password reset."
+                })
+            elif result == 2:
+                response = jsonify({
+                    "statusCode":
+                    206,
+                    "message":
+                    "Created the admin but could not reset password."
+                })
+            elif result == 0:
+                response = jsonify({
+                    "statusCode": 400,
+                    "message": "Could not make the admin."
+                })
+            elif result == -1:
+                response = jsonify({
+                    "statusCode":
+                    410,
+                    "message":
+                    "There is an admin with that email already."
+                })
+            else:
+                response = jsonify({
+                    "statusCode": 400,
+                    "message": "Unexpected error."
+                })
+        except Exception:
+            response = jsonify({
+                "statusCode": 500,
+                'message': "Internal server error"
             })
-        elif result == 2:
-            return jsonify({
-                "statusCode":
-                206,
-                "message":
-                "Created the admin but could not reset password."
-            })
-        elif result == 0:
-            return jsonify({
-                "statusCode": 400,
-                "message": "Could not make the admin."
-            })
-        elif result == -1:
-            return jsonify({
-                "statusCode":
-                410,
-                "message":
-                "There is an admin with that email already."
-            })
-        else:
-            return jsonify({"statusCode": 400, "message": "Unexpected error."})
-    except Exception:
-        return jsonify({"statusCode": 500, 'message': "Internal server error"})
+    return response

--- a/src/flaskr/app/modules/api/admin/put.py
+++ b/src/flaskr/app/modules/api/admin/put.py
@@ -1,20 +1,13 @@
 from flask import jsonify, request, make_response
 from flask_restplus.namespace import RequestParser, request
-from ...resources.admin  import AdminManagement
+from ...resources.admin import AdminManagement
 from flask_jwt_extended import (create_access_token, create_refresh_token)
-
+from ...resources.validation import is_admin, is_not_admin_response
 #################
 # Parser        #
 #################
 Parser = RequestParser()
-Parser.add_argument('Authorization',
-                    help="Admin's session token",
-                    required=True)
 Parser.add_argument('current_password',
-                    help='Current password of admin',
-                    required=True,
-                    location='form')
-Parser.add_argument('password',
                     help='Current password of admin',
                     required=True,
                     location='form')
@@ -35,10 +28,22 @@ Parser.add_argument('new_password',
 # Method        #
 #################
 
-def Put(args):
-    am = AdminManagement()
-    response = jsonify({"": ""})
-    if args['code'] and args['email']:
-        response = am.create_password(args['code'], args['password'], args['email'])
+
+def Put(args, identity):
+    if not is_admin(identity):
+        response = is_not_admin_response
+    else:
+        password = args["current_password"]
+        first_name = args["first_name"]
+        last_name = args["last_name"]
+        new_password = None if not args["new_password"] else args[
+            "new_password"]
+        am = AdminManagement()
+        #Implement the method here
+
+        response = jsonify({
+            "statusCode": 500,
+            "message": "Not yet implemented"
+        })
 
     return response

--- a/src/flaskr/app/modules/api/product/admin/put.py
+++ b/src/flaskr/app/modules/api/product/admin/put.py
@@ -50,7 +50,7 @@ def Put(args, identity):
     name = None if not args['name'] else args['name']
     price = None if not args['price'] else args['price']
     picture = None if not args['picture'] else args['picture']
-    description = 'No description' if not args['description'] else args[
+    description = None if not args['description'] else args[
         'description']  #Do this for optional fields
     digital = None if not args['digital'] else args['digital']
     image_name = None

--- a/src/flaskr/app/modules/api/product/admin/put.py
+++ b/src/flaskr/app/modules/api/product/admin/put.py
@@ -67,7 +67,10 @@ def Put(args, identity):
             print("Image result was: {}".format(image_result))
             image_name = image_result["link"]
             tmpDir.cleanup()
-
+        else:
+            image_name = None
+            image_result = {"status": 200}
+            #Pretend it was successful
         ap = AdminProduct()
         result = ap.update_product(pId,
                                    name,


### PR DESCRIPTION
This branch will contain a bunch of fixes to solve #92  issues.

- Admin/Management POST: (#71) Allows to make an admin ~~(Does not require admin token yet to not cause a deadlock. Will be implemented in the future)~~ Now all endpoints in Admin/Management have the base for JWT check. POST no longer allows to make new admins if user isn't a logged in admin already. 
