### PR TITLE
Implemented inclusive-filtering for customer orders

### DIFF
--- a/src/flaskr/app/modules/api/order/admin/get.py
+++ b/src/flaskr/app/modules/api/order/admin/get.py
@@ -13,7 +13,7 @@ Parser.add_argument('sort',
 Parser.add_argument(
     'filter',
     help=
-    'A comma separated string of all the status names that we are excluding. Capitalizes the first letter of each word.',
+    'A comma separated string of all the status names that we are excluding. Capitalizes the first letter of each word internally.',
     required=False)
 Parser.add_argument('page',
                     type=int,

--- a/src/flaskr/app/modules/api/order/user/get.py
+++ b/src/flaskr/app/modules/api/order/user/get.py
@@ -9,10 +9,9 @@ Parser.add_argument('sort',
                     type=int,
                     help='ID of the sorting method to be used (NYI)',
                     required=False)
-Parser.add_argument(
-    'filter',
-    help='A comma separated string of all the filters that apply (NYI)',
-    required=False)
+Parser.add_argument('filter',
+                    help='Comma separated string of all filters that apply. If left blank it will give every order. Otherwise it will be an inclusive filter. Only giving out the statuses that are in the filter.',
+                    required=False)
 Parser.add_argument('page',
                     type=int,
                     help='Page the request is asking for',
@@ -23,7 +22,7 @@ Parser.add_argument('page',
 
 
 def Get(args, identity):
-    filter = " " if not args['filter'] else args['filter']
+    filter = args['filter']
     sort = 0 if not args['sort'] else args['sort']
     page = 0 if not args['page'] else args['page']
 

--- a/src/flaskr/app/modules/resources/order/__init__.py
+++ b/src/flaskr/app/modules/resources/order/__init__.py
@@ -24,6 +24,7 @@ class UserOrder():
             value = str(tmp_statuses[i]["_id"])
             self.statuses[key] = value
             self.value_to_status[value] = key
+        self.status_names = [x for x in self.statuses.keys()]
 
     def find_in_checkout_order(self, user_id):
         return self.db.find(
@@ -144,8 +145,18 @@ class UserOrder():
         return response
 
     def get_user_orders(self, user_id, filter, sort, ascending=True, page=0):
+        if filter is None:
+            include_list = self.status_names
+        else:
+            include_list = [x.strip().title() for x in filter.split(',')]
+
+        search_in = [{
+            "status": ObjectId(self.statuses[x]),
+            'customer_id': ObjectId(user_id)
+        } for x in include_list]
+
         orders = self.db.find_all(self.collection_name,
-                                  {'customer_id': ObjectId(user_id)}, sort,
+                                  {"$or":search_in}, sort,
                                   ascending, page)
         response = []
         for order in orders:


### PR DESCRIPTION
Should close #124

Customers orders can receive the parameter filter

- If filter is left empty it will include EVERY status
- If filter has the status _x_ it will only display orders with the status of _x_ (Inclusive filtering) and not any that are not _x_
- The filter you want is `pending` 

UPDATE

- Orders PUT also validates if Billing and Shipping index are wrong, if they are out of index range it returns a 410 and a message that indicates which one is wrong. Front end should send a new Customers GET to refresh their addresses